### PR TITLE
ci: add pypi environment to release job for OIDC protection

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -164,6 +164,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    environment: pypi
     permissions:
       id-token: write
     needs:


### PR DESCRIPTION
## Summary

Adds `environment: pypi` to the release job so PyPI publishing is gated by a GitHub Environment.

This is the workflow-side prerequisite for locking down the PyPI OIDC trust:

- Allows the `pypi` environment to have deployment branch rules (limit to `main` explicitly).
- Allows mandatory approval reviewers on the environment before any publish step runs.
- Ensures PyPI trusted publishing can be scoped to this specific environment name.

## Next steps (repo/settings required)

1. In **GitHub repo settings → Environments → `pypi`**:
   - Set **Deployment branches** to only allow `main` (listed explicitly, no patterns).
   - Add at least **1 required reviewer** (recommended: 2).

2. In **GitHub repo settings → Branch protection rules for `main`**:
   - Require a pull request before merging.
   - Require at least 1 approving review.

3. In **PyPI project settings → Trusted Publishing**:
   - Update/create the trusted publisher to require the `pypi` environment.

These settings together prevent a user with write access from directly pushing a tag and triggering an unreviewed/unapproved PyPI publish.